### PR TITLE
Analog and digital gain control addition through pipe

### DIFF
--- a/host_applications/linux/apps/raspicam/Config.md
+++ b/host_applications/linux/apps/raspicam/Config.md
@@ -168,3 +168,4 @@ The main Pipe is FIFO which is used by the python script. Commands may also be s
 |cn|1/2|Set camera number (Compute module only)|
 |qp|A BB CC|Set h264 encoding pars A=minimise_frag BB=initial_quant CC=encode_qp|
 |ls|Number|Set log_size|
+|ig|ANA DIG|set image gain, analog and digital (100 = 1.0; default: 150)|

--- a/host_applications/linux/apps/raspicam/RaspiMCam.c
+++ b/host_applications/linux/apps/raspicam/RaspiMCam.c
@@ -963,6 +963,23 @@ void cam_set_autowbgain() {
     error("Could not set sensor area", 0);
 }
 
+void cam_set_gains() {
+  MMAL_RATIONAL_T rational = {0, 65536};
+  MMAL_STATUS_T status;
+
+  rational.num = (unsigned int)(cfg_val[c_analog_gain] * 655.36);
+  status = mmal_port_parameter_set_rational(
+      camera->control, MMAL_PARAMETER_ANALOG_GAIN, rational);
+  if (status != MMAL_SUCCESS)
+    error("Could not set analog gain", 0);
+
+  rational.num = (unsigned int)(cfg_val[c_digital_gain] * 655.36);
+  status = mmal_port_parameter_set_rational(
+      camera->control, MMAL_PARAMETER_DIGITAL_GAIN, rational);
+  if (status != MMAL_SUCCESS)
+    error("Could not set digital gain", 0);
+}
+
 void cam_get_sensor(void) {
   MMAL_COMPONENT_T *camera_info;
   MMAL_STATUS_T status;
@@ -1092,6 +1109,9 @@ void cam_set(int key) {
     break;
   case c_autowbgain_r:
     cam_set_autowbgain();
+    break;
+  case c_analog_gain:
+    cam_set_gains();
     break;
   }
 

--- a/host_applications/linux/apps/raspicam/RaspiMCmds.c
+++ b/host_applications/linux/apps/raspicam/RaspiMCmds.c
@@ -105,12 +105,13 @@ void process_cmd(char *readbuf, int length) {
     cn,
     st,
     ls,
-    qp
+    qp,
+    ig
   } pipe_cmd_type;
   char pipe_cmds[] =
       "ca,im,tl,px,bo,tv,vi,an,as,at,ac,ab,sh,co,br,sa,is,vs,rl,ec,em,wb,ag,mm,"
       "fn,ie,ce,ro,fl,ri,ss,qu,pv,bi,ru,md,sc,rs,bu,mn,mt,mi,ms,mb,me,mc,mx,mf,"
-      "mz,vm,vp,wd,sy,um,cn,st,ls,qp";
+      "mz,vm,vp,wd,sy,um,cn,st,ls,qp,ig";
   pipe_cmd_type pipe_cmd;
   int parcount;
   char pars[128][10];
@@ -151,6 +152,9 @@ void process_cmd(char *readbuf, int length) {
     par0 = 0;
   }
 
+  // if key is used in this switch, the value is added at the end by calling a
+  // specific function if two parameters are passed to set two config, one
+  // first use pars[1], pars[0] is parsed at the end
   switch (pipe_cmd) {
   case ca:
     if (par0 == 1) {
@@ -454,6 +458,10 @@ void process_cmd(char *readbuf, int length) {
     break;
   case ls:
     key = c_log_size;
+    break;
+  case ig:
+    addUserValue(c_digital_gain, pars[1]);
+    key = c_analog_gain;
     break;
   default:
     printLog("Unrecognised pipe command\n");

--- a/host_applications/linux/apps/raspicam/RaspiMJPEG.c
+++ b/host_applications/linux/apps/raspicam/RaspiMJPEG.c
@@ -194,7 +194,9 @@ char *cfg_key[] = {"annotation",
                    "initial_quant",
                    "encode_qp",
                    "mmal_logfile",
-                   "stop_pause"};
+                   "stop_pause",
+                   "analog_gain",
+                   "digital_gain"};
 
 void term(int signum) { running = 0; }
 

--- a/host_applications/linux/apps/raspicam/RaspiMJPEG.h
+++ b/host_applications/linux/apps/raspicam/RaspiMJPEG.h
@@ -92,7 +92,7 @@ extern char *box_files[MAX_BOX_FILES];
 extern int box_head;
 extern int box_tail;
 // hold config file data for both dflt and user config files and u long versions
-#define KEY_COUNT 109
+#define KEY_COUNT 111
 extern char *cfg_strd[KEY_COUNT + 1];
 extern char *cfg_stru[KEY_COUNT + 1];
 extern long int cfg_val[KEY_COUNT + 1];
@@ -110,6 +110,8 @@ extern int mask_disabled;
 extern unsigned char *vector_buffer;
 extern unsigned char *mask_buffer_mem, *mask_buffer;
 
+// cfgkey_type must be in the same order as the key list in *cfg_key[] (see in
+// raspiMJPEG.c) also, KEY_COUNT must be updated to reflect the change
 typedef enum cfgkey_type {
   c_annotation,
   c_anno_background,
@@ -220,6 +222,8 @@ typedef enum cfgkey_type {
   c_encode_qp,
   c_mmal_logfile,
   c_stop_pause,
+  c_analog_gain,
+  c_digital_gain
 } cfgkey_type;
 
 // Utils
@@ -263,6 +267,7 @@ void cam_set_ce();
 void cam_set_flip();
 void cam_set_roi();
 void cam_set_autowbgain();
+void cam_set_gains();
 void cam_set(int key);
 void h264_enable_output();
 void start_all(int load_conf);


### PR DESCRIPTION
Similar to the way the white balance gain is set, send a `ig ANA DIG` command through the pipe, with ANA being the analog gain * 100 (100 for 1.00) and DIG being the digital gain * 100 (100 for 1.00)